### PR TITLE
feat: Create database migrations and schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -307,6 +308,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug

--- a/db/migrate/20240814210726_create_users.rb
+++ b/db/migrate/20240814210726_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+      t.integer :credits
+      t.integer :roundup_status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240814211929_create_questions.rb
+++ b/db/migrate/20240814211929_create_questions.rb
@@ -1,0 +1,11 @@
+class CreateQuestions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :questions do |t|
+      t.string :question
+      t.string :response
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,37 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_211929) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "questions", force: :cascade do |t|
+    t.string "question"
+    t.string "response"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
+    t.integer "credits"
+    t.integer "roundup_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "questions", "users"
+end


### PR DESCRIPTION
This branch adds the following:
- Uncomments Bcrypt gem for basic auth (to be used later in process)
- Adds migration for Users table with:
   - name - string
   - email - string
   - password_digest - string
   - credits - integer
   - roundup_status - integer (will be used as enum)
- Adds migration for Questions table with:
   - question - string
   - response - string
   - user_id - string
