### PR TITLE
Create user account

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,5 @@
  *
  *= require_tree .
  *= require_self
+ *= require login-form
  */

--- a/app/assets/stylesheets/login-form.css
+++ b/app/assets/stylesheets/login-form.css
@@ -1,0 +1,102 @@
+@import url(https://fonts.googleapis.com/css?family=Roboto:300);
+
+.title {
+  text-align: center;
+  font-family: "Roboto", sans-serif;
+  font-size: large;
+  color: white;
+}
+
+.login-page {
+  width: 360px;
+  padding: 8% 0 0;
+  margin: auto;
+}
+.form {
+  position: relative;
+  z-index: 1;
+  max-width: 360px;
+  margin: 0 auto 100px;
+  padding: 45px;
+  text-align: center;
+}
+.form input {
+  font-family: "Roboto", sans-serif;
+  outline: 0;
+  background: #f2f2f2;
+  width: 100%;
+  border: 0;
+  margin: 0 0 15px;
+  padding: 15px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+.form button {
+  font-family: "Roboto", sans-serif;
+  text-transform: uppercase;
+  outline: 0;
+  background: #818181;
+  width: 100%;
+  border: 0;
+  padding: 15px;
+  color: #FFFFFF;
+  font-size: 14px;
+  -webkit-transition: all 0.3 ease;
+  transition: all 0.3 ease;
+  cursor: pointer;
+}
+.form button:hover,.form button:active,.form button:focus {
+  background: #000000;
+}
+.form .message {
+  margin: 15px 0 0;
+  color: #b3b3b3;
+  font-size: 12px;
+}
+.form .message a {
+  color: #4CAF50;
+  text-decoration: none;
+}
+.form .register-form {
+  display: none;
+}
+.container {
+  position: relative;
+  z-index: 1;
+  max-width: 300px;
+  margin: 0 auto;
+}
+.container:before, .container:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+.container .info {
+  margin: 50px auto;
+  text-align: center;
+}
+.container .info h1 {
+  margin: 0 0 15px;
+  padding: 0;
+  font-size: 36px;
+  font-weight: 300;
+  color: #1a1a1a;
+}
+.container .info span {
+  color: #4d4d4d;
+  font-size: 12px;
+}
+.container .info span a {
+  color: #000000;
+  text-decoration: none;
+}
+.container .info span .fa {
+  color: #EF3B3A;
+}
+body {
+  background: #494a49;
+  background: linear-gradient(90deg, rgb(0, 0, 0) 0%, rgb(63, 63, 63) 50%);
+  font-family: "Roboto", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;      
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::Base
+  private
+  def error_message(errors)
+    errors.full_messages.join(', ')
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,21 @@
+class UsersController < ApplicationController
+  def new
+  end
+
+  def create
+    user = User.new(user_params)
+    if user.save
+      flash[:success] = "Account created"
+      session[:user_id] = user.id 
+      redirect_to "/home"
+    else
+      flash[:error] = "#{error_message(user.errors)}"
+      redirect_to "/users/new"
+    end
+  end
+
+  private
+  def user_params
+    params.permit(:name, :email, :password, :password_confirmation, :roundup_status)
+  end
+end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,7 @@
+class WelcomeController < ApplicationController
+  def index
+    if session[:user_id]
+      redirect_to '/home'
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  validates :name, :email, :password, presence: true
+  validates :name, :password, presence: true
+  validates :email, presence: true, uniqueness: true
   validates :credits, presence: true, numericality: true
   has_many :questions, dependent: :destroy
   has_secure_password

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,11 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div id="mainBody" class="container">
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg, class: name %>
+      <% end %>
+      <%= yield %>  
+    </div>
   </body>
 </html>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,20 @@
+<div class="login-page">
+  <div class="form">
+    <%= form_with url: "/users", method: :post, local: true, data: {turbo: false} do |form|%>
+      <%= form.text_field :name, placeholder: "Name" %><br>
+      <%= form.text_field :email, placeholder: "Email Address" %><br>
+      <%= form.password_field :password, placeholder: "Password" %><br>
+      <%= form.password_field :password_confirmation, placeholder: "Password Confirmation" %>
+      <p class="message">Weekly Round Up Email</p>
+      <div id="enabled">
+        <%= form.label :status_enabled, "Enabled", class: "message" %>
+        <%= form.radio_button :roundup_status, "enabled" %>
+      </div>
+      <div id="disabled">
+        <%= form.label :status_disabled, "Disabled", class: "message" %>
+        <%= form.radio_button :roundup_status, "disabled" %>
+      </div>
+      <%= form.button "Create Account" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,11 @@
+<div class="login-page">
+  <h1 class="title">The Crawfather awaits...</h1>
+  <div class="form">
+    <%= form_with url: "/login", method: :post, local: true, data: {turbo: false}, class: "login-form" do |form|%>
+      <%= form.text_field :email, placeholder: "Email" %><br>
+      <%= form.text_field :password, placeholder: "Password" %><br>
+      <%= form.button "Login"%>
+    <% end %>
+    <p class="message">Not registered? <a href="/users/new">Create Account</a></p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  root 'welcome#index'
+  post '/login', to: 'sessions#create'
+  get '/users/new', to: 'users#new'
+  post '/users', to: 'users#create'
+  get '/home', to: 'home#show'
 end

--- a/db/migrate/20240814210726_create_users.rb
+++ b/db/migrate/20240814210726_create_users.rb
@@ -4,7 +4,7 @@ class CreateUsers < ActiveRecord::Migration[7.1]
       t.string :name
       t.string :email
       t.string :password_digest
-      t.integer :credits
+      t.integer :credits, default: 5
       t.integer :roundup_status
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_211929) do
     t.string "name"
     t.string "email"
     t.string "password_digest"
-    t.integer "credits"
+    t.integer "credits", default: 5
     t.integer "roundup_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/features/users/create_account_spec.rb
+++ b/spec/features/users/create_account_spec.rb
@@ -2,10 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Create User Account', type: :feature do
   describe 'As a User' do
-    before(:each) do
-      
-    end
-
     describe '#Happy Path' do
       it 'can visit the landing page and see an option to create a new account or to sign in' do
         visit '/'
@@ -36,8 +32,42 @@ RSpec.describe 'Create User Account', type: :feature do
     end
 
     describe '#Sad Path' do
-      it '' do
+      it 'will not create a new account if not given needed info' do
+        user_count = User.all.length
+        visit '/users/new'
+        
+        fill_in 'Name', with: "test name"
+        fill_in 'Email Address', with: "test@email.com"
+        fill_in 'Password', with: "password"
+        within '#enabled' do
+          choose 'roundup_status'
+        end
+        click_button 'Create Account'
 
+        expect(current_path).to eq('/users/new')
+        expect(page).to have_content("Password confirmation doesn't match Password")
+        expect(user_count).to eq(0)
+      end
+
+      it 'will not make an account with an email address that is already taken by a different User' do
+        visit '/users/new'
+
+        User.create!({name:"tester", email:"test@email.com", password:"password", password_confirmation:"password", roundup_status:1})
+
+        user_count = User.all.length
+
+        fill_in 'Name', with: "test name"
+        fill_in 'Email Address', with: "test@email.com"
+        fill_in 'Password', with: "password"
+        fill_in 'Password Confirmation', with: "password"
+        within '#enabled' do
+          choose 'roundup_status'
+        end
+        click_button 'Create Account'
+
+        expect(current_path).to eq("/users/new")
+        expect(page).to have_content("Email has already been taken")
+        expect(user_count).to eq(1)
       end
     end
   end

--- a/spec/features/users/create_account_spec.rb
+++ b/spec/features/users/create_account_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Create User Account', type: :feature do
+  describe 'As a User' do
+    before(:each) do
+      
+    end
+
+    describe '#Happy Path' do
+      it 'can visit the landing page and see an option to create a new account or to sign in' do
+        visit '/'
+
+        expect(page).to have_content("The Crawfather awaits...")
+        expect(page).to have_button("Login")
+        expect(page).to have_link("Create Account", href: "/users/new")
+      end
+
+      it 'can click the create an account button and be taken to the page to create their account' do
+        visit '/'
+        click_link 'Create Account'
+
+        expect(current_path).to eq('/users/new')
+        
+        fill_in 'Name', with: "test name"
+        fill_in 'Email Address', with: "test@email.com"
+        fill_in 'Password', with: "password"
+        fill_in 'Password Confirmation', with: "password"
+        within '#enabled' do
+          choose 'roundup_status'
+        end
+        click_button 'Create Account'
+
+        expect(current_path).to eq('/home')
+        expect(User.all.last.name).to eq("test name")
+      end
+    end
+
+    describe '#Sad Path' do
+      it '' do
+
+      end
+    end
+  end
+end

--- a/spec/features/welcome/welcome_page_spec.rb
+++ b/spec/features/welcome/welcome_page_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Welcome Page', type: :feature do
+  describe 'As a visitor' do
+    it 'can see the welcome page info and login form' do
+      visit '/'
+
+      expect(page).to have_content("The Crawfather awaits...")
+      expect(page).to have_field("email")
+      expect(page).to have_field("password")
+      expect(page).to have_button("Login")
+      expect(page).to have_link("Create Account", href: "/users/new")
+    end
+  end
+end

--- a/spec/models/user/user_spec.rb
+++ b/spec/models/user/user_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email) }
     it { should validate_presence_of(:password) }
     it { should validate_presence_of(:credits) }
     it { should validate_numericality_of(:credits) }


### PR DESCRIPTION
**This branch adds the following:**
- Migrations updated to add a default numeric value for user accounts to start with 5 "credits"
   - These will be used later to monitor how often a user is hitting the chat bot so it doesn't get abused
- User model now validates email uniqueness so there won't be overlapping email addresses in DB
- Routes:
   - GET "/" - home page with login form
   - GET "/users/new" - user account creation form page
   - POST "/users" - where /users/new sends form data to create user in database
   - GET "/home" - where users will be sent to after login and account creation
   - POST "/login" - will be used to create session before sending user to home (may be removed as I don't think I'll need custom session setup at this time)
- Login form and create user account form are styled with the same CSS stylesheet
- Flash messages are able to be viewed app wide
- Simple error message handling set up in application controller
   - will need to be updated once login process is built out to not reveal what input is incorrect (password/email)

**Testing:**
- Testing coverage at 99.04%
   - Current lapse in coverage coming from welcome controller that is holding user login form but no testing for it yet