### PR TITLE
User dashboard page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem "shoulda-matchers"
   gem "dotenv-rails"
   gem "launchy"
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,11 @@ GEM
     error_highlight (0.6.0)
     erubi (1.13.0)
     event_stream_parser (1.0.0)
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
       logger
@@ -327,6 +332,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   error_highlight (>= 0.4.0)
+  factory_bot_rails
   faraday
   importmap-rails
   jbuilder

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,5 +12,4 @@
  *
  *= require_tree .
  *= require_self
- *= require login-form
  */

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -1,0 +1,18 @@
+@import url(https://fonts.googleapis.com/css?family=Roboto:300);
+
+body .dashboard {
+  margin: 0;
+}
+
+#dashboard-account-info{
+  position: relative;
+  padding: 30px;
+  color: #FFFFFF;
+  width: 600px;
+  height: fit-content;
+  border: 1px solid black;
+  padding: 10px;
+  margin: 10px;
+  background-color: #818181;
+}
+

--- a/app/assets/stylesheets/login-form.css
+++ b/app/assets/stylesheets/login-form.css
@@ -63,7 +63,6 @@
 .container {
   position: relative;
   z-index: 1;
-  max-width: 300px;
   margin: 0 auto;
 }
 .container:before, .container:after {
@@ -94,12 +93,11 @@
   color: #EF3B3A;
 }
 body {
-  font-family: "Roboto", sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;      
+  font-family: "Roboto", sans-serif;    
   background-image: url('shrimp.png');
   background-color: #cccccc;
   background-size: cover;
+  background-repeat: no-repeat;
 }
 
 .question {
@@ -153,3 +151,4 @@ body {
   box-sizing: border-box;
   font-size: 14px;
 }
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < ApplicationController
       @user = User.find(session[:user_id])
     else
       redirect_to root_path
+      flash[:error] = "You must be logged in to view your dashboard page"
     end
   end
 

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,1 +1,24 @@
-<%= button_to "Edit Account", '/edit', method: :get %>
+<div class=form>
+  <%= button_to "Edit Account", '/edit', method: :get %>
+  <%= button_to "Log Out", '/logout', method: :delete %>
+  <%= button_to "Delete Account", '/logout', method: :delete %>
+  <%= button_to "Return to the Crawfather", '/home', method: :get %>
+</div>
+<body class=dashboard>
+  <div id=dashboard-account-info>
+    <p>Name: <%= @user.name %></p>
+    <p>Credits Remaining: <%= @user.credits %></p>
+    <p>Last 5 Questions for the Crawfather:</p>
+    <% if @user.questions %>
+      <ul>
+        <% @user.questions.reverse_each do |question| %>
+          <div id="question-<%= question.id %>">
+            <li>Question: <%= question.question %></li>
+            <li>Response: <%= question.response %></li>
+          </div>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</body>    
+

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :question do
+    question { "Question" }
+    response { "Response" }
+    user_id { 1 }
+  end
+end

--- a/spec/features/users/user_dashboard_page_spec.rb
+++ b/spec/features/users/user_dashboard_page_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'User Dashboard Page' do
-  describe 'As a User' do 
+  describe 'As a logged in User' do 
+    
     before(:each) do
       user_params = {name: "test", email: "test@email.com", password: "password", password_confirmation: "password", roundup_status: 1}
       @user = User.create!(user_params)
@@ -9,52 +10,57 @@ RSpec.describe 'User Dashboard Page' do
       fill_in 'Email', with: "test@email.com"
       fill_in 'Password', with: "password"
       click_button 'Login'
-
+      
       5.times do
         create(:question, user_id: @user.id)
       end
     end
-# Show name and list of questions asked
-# Button to return to the crawfather
-# Button to edit account
-# Button to activate/deactivate weekly round up emails
-# Button to delete account
+    
     it 'sees its own name, number of credits left, the last 5 questions its asked, the responses, and their dates in the dashboard' do
       visit '/dashboard'
-
+      
       expect(page).to have_content("Name: test")
       expect(page).to have_content("Credits Remaining: 5")
       expect(page).to have_content("Last 5 Questions for the Crawfather:")
       (1..5).each do |num|
         within "#question-#{num}" do
-          expect(page).to have_content("Question")
-          expect(page).to have_content("Response")
-        end
+        expect(page).to have_content("Question")
+        expect(page).to have_content("Response")
       end
     end
-
-    it 'sees a button to delete its account' do
-      visit '/dashboard'
-      expect(page).to have_button("Delete Account")
+  end
+  
+  it 'sees a button to delete its account' do
+    visit '/dashboard'
+    expect(page).to have_button("Delete Account")
+  end
+  
+  it 'sees options to enable or disable their weekly roundup emails' do
+    visit '/dashboard'
+    
+    within '#enabled' do
+      expect(page).to have_field('roundup_status')
     end
-
-    it 'sees options to enable or disable their weekly roundup emails' do
-      visit '/dashboard'
-
-      within '#enabled' do
-        expect(page).to have_field('roundup_status')
-      end
-      
-      within '#disabled' do
-        expect(page).to have_field('roundup_status')
-      end
+    
+    within '#disabled' do
+      expect(page).to have_field('roundup_status')
     end
+  end
 
-    it 'sees a button to return to the crawfather to ask more questions' do
+  it 'sees a button to return to the crawfather to ask more questions' do
       visit '/dashboard'
       click_button 'Return to the Crawfather'
-
+      
       expect(current_path).to eq('/home')
+    end
+  end
+
+  describe 'As a not logged in user' do
+    it 'does not allow you to see your dashboard unless you are logged in' do
+      visit '/dashboard'
+    
+      expect(current_path).to eq('/')
+      expect(page).to have_content('You must be logged in to view your dashboard page')
     end
   end
 end

--- a/spec/features/users/user_dashboard_page_spec.rb
+++ b/spec/features/users/user_dashboard_page_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'User Dashboard Page' do
+  describe 'As a User' do 
+    before(:each) do
+      user_params = {name: "test", email: "test@email.com", password: "password", password_confirmation: "password", roundup_status: 1}
+      @user = User.create!(user_params)
+      visit '/'
+      fill_in 'Email', with: "test@email.com"
+      fill_in 'Password', with: "password"
+      click_button 'Login'
+
+      5.times do
+        create(:question, user_id: @user.id)
+      end
+    end
+# Show name and list of questions asked
+# Button to return to the crawfather
+# Button to edit account
+# Button to activate/deactivate weekly round up emails
+# Button to delete account
+    it 'sees its own name, number of credits left, the last 5 questions its asked, the responses, and their dates in the dashboard' do
+      visit '/dashboard'
+
+      expect(page).to have_content("Name: test")
+      expect(page).to have_content("Credits Remaining: 5")
+      expect(page).to have_content("Last 5 Questions for the Crawfather:")
+      (1..5).each do |num|
+        within "#question-#{num}" do
+          expect(page).to have_content("Question")
+          expect(page).to have_content("Response")
+        end
+      end
+    end
+
+    it 'sees a button to delete its account' do
+      visit '/dashboard'
+      expect(page).to have_button("Delete Account")
+    end
+
+    it 'sees options to enable or disable their weekly roundup emails' do
+      visit '/dashboard'
+
+      within '#enabled' do
+        expect(page).to have_field('roundup_status')
+      end
+      
+      within '#disabled' do
+        expect(page).to have_field('roundup_status')
+      end
+    end
+
+    it 'sees a button to return to the crawfather to ask more questions' do
+      visit '/dashboard'
+      click_button 'Return to the Crawfather'
+
+      expect(current_path).to eq('/home')
+    end
+  end
+end

--- a/spec/features/users/user_dashboard_page_spec.rb
+++ b/spec/features/users/user_dashboard_page_spec.rb
@@ -14,18 +14,25 @@ RSpec.describe 'User Dashboard Page' do
       5.times do
         create(:question, user_id: @user.id)
       end
+
+      q_1 = @user.questions[4]
+      q_2 = @user.questions[3]
+      q_3 = @user.questions[2]
+      q_4 = @user.questions[1]
+      q_5 = @user.questions[0]
+      @questions = [q_1, q_2, q_3, q_4, q_5]
     end
     
-    it 'sees its own name, number of credits left, the last 5 questions its asked, the responses, and their dates in the dashboard' do
+    it 'sees its own name, number of credits left, the last 5 questions its asked, the responses' do
       visit '/dashboard'
       
       expect(page).to have_content("Name: test")
       expect(page).to have_content("Credits Remaining: 5")
       expect(page).to have_content("Last 5 Questions for the Crawfather:")
-      (1..5).each do |num|
-        within "#question-#{num}" do
-        expect(page).to have_content("Question")
-        expect(page).to have_content("Response")
+      @questions.each do |question|
+        within "#question-#{question.id}" do
+          expect(page).to have_content("Question")
+          expect(page).to have_content("Response")
       end
     end
   end
@@ -33,18 +40,6 @@ RSpec.describe 'User Dashboard Page' do
   it 'sees a button to delete its account' do
     visit '/dashboard'
     expect(page).to have_button("Delete Account")
-  end
-  
-  it 'sees options to enable or disable their weekly roundup emails' do
-    visit '/dashboard'
-    
-    within '#enabled' do
-      expect(page).to have_field('roundup_status')
-    end
-    
-    within '#disabled' do
-      expect(page).to have_field('roundup_status')
-    end
   end
 
   it 'sees a button to return to the crawfather to ask more questions' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end
 
 # shoulda matchers config
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
This branch adds the following:
- Adds Factory Bot gem to allow for ease in model instantiation in testing files
- Adds additional stylesheet for User Dashboard Page
- Adds the following functionalities to the User Dashboard page:
   - Ability to navigate back to crawfather/home, edit account page, and log out of account
   - User can see their previous questions and the responses from the crawfather in order of most recent questions to first
   - User can see the name associated with their account
   - User can see the number of credits that they have remaining in their account

Code Coverage: 98.81%